### PR TITLE
Improved README and docker-compose.yml with pre-build image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ADDARR
+![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/waterboy1602/addarr)
 
 This is a TelegramBot made to add series to [Sonarr](https://github.com/Sonarr/Sonarr) or movies to [Radarr](https://github.com/Radarr/Radarr) with a couple of commands.
 
@@ -15,9 +16,8 @@ The rest will be made clear by the bot.
 
 ## INSTALLATION
 For the moment there is only an installationguide for [FreeBSD](https://github.com/Waterboy1602/Addarr/wiki/Installation-on-FreeBSD) and Docker. If there is interest for other guides, just tell me and I will look for it.
-### Docker 
-* To build a docker image use the command `docker-compose build`.
-* After that copy the provided `config_example.yaml` to `config.yaml` and set the values to your configuration.
+### Docker
+* Copy the provided `config_example.yaml` to `config.yaml` and set the values to your configuration.
 * Then you can use the provided docker-compose file to run the bot using the command `docker-compose up -d`.
 
 All the credits for the docker setup go to [@tedvdb](https://github.com/tedvdb)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: '3'
 services:
   addarr:
-    container_name: addarr_bot
-    build: .
+    image: waterboy1602/addarr
     restart: unless-stopped
     network_mode: host
     volumes:


### PR DESCRIPTION
As a follow up on #6 I have added a shields.io docker badge to the README (so it is instantly clear to people that they can just docker pull the image). And I tweaked the docker-compose.yml to use the prebuild image as well so there's no need anymore to build the image yourself.