### PR TITLE
Share chatid.txt with the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
     network_mode: host
     volumes:
     - ./config.yaml:/usr/src/addarr/config.yaml:ro
+    - ./chatid.txt:/usr/src/addarr/chatid.txt:rw


### PR DESCRIPTION
This way if Addarr is running in docker the chatid.txt file actually properly persist.