### PR TITLE
Path is now configurable

### DIFF
--- a/commons.py
+++ b/commons.py
@@ -20,7 +20,8 @@ def generateServerAddr(app):
         try:
             addr = config[app]["server"]["addr"]
             port = config[app]["server"]["port"]
-            return http + addr + ":" + str(port)
+            path = config[app]["server"]["path"]
+            return http + addr + ":" + str(port) + path
         except Exception:
             logger.warn("No ip or port defined.")
     except Exception as e:
@@ -36,7 +37,7 @@ def generateApiQuery(app, endpoint, parameters={}):
     try:
         apikey = config[app]["auth"]["apikey"]
         url = (
-            generateServerAddr(app) + "/api/" + str(endpoint) + "?apikey=" + str(apikey)
+            generateServerAddr(app) + "api/" + str(endpoint) + "?apikey=" + str(apikey)
         )
         # If parameters exist iterate through dict and add parameters to URL.
         if parameters:

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -6,6 +6,7 @@ sonarr:
   server:
     addr: 
     port : 8989 # Default is 8989
+    path: / # Default is / . If set, it must start and finish with / . Eg: /sonarr/
     ssl: false #default false
   auth:
     apikey: 
@@ -20,6 +21,7 @@ radarr:
   server:
     addr:
     port : 7878 # Default is 7878
+    path: / # Default is / . If set, it must start and finish with / . Eg: /radarr/
     ssl: false #default false
   auth:
     apikey:


### PR DESCRIPTION
This sorts the issue when sonarr or radarr is behind a reverse proxy.
For those not using reverse proxies, one can just leave the config as `/`.

Fixes #36 as I tested to add shows and movies.