### PR TITLE
Add qualityProfile tags configTextIdentifiers listOnlyAdmins Allowlist and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Every command does also work if you send a message without `/` and no other word
 An example of the config file (`config_example.yaml`) can be found in this repository. Change it to your configuration. After you've filled in all the necessary fields, rename it to `config.yaml`.
 
 ## ADMIN    
-There is a functionality to only let admins use the `transmission` command. Before you can use this, you should enable it in the config file `config.yaml`. Then you need to add the admins to `admin.txt`. You can add the `username` or `id` of the user. Every added user should be on a new line to prevent errors.
+There is a functionality to only let admins use the `transmission` command, list all series  from `sonarr`or all movies from `radarr`. Before you can use this, you should enable each variable in the config file `config.yaml`. Then you need to add the admins to `admin.txt`. You can add the `username` or `id` of the user. Every added user should be on a new line to prevent errors.
+
+## ALLOWLIST   
+There is a very restrictive functionality to only reply to already approbed users. You can enable it in the config file `config.yaml`. Then you need to add the users to `allowlist.txt`. You can add the `username` or `id` of the user. Every added user should be on a new line to prevent errors.
 
 ## INSTALLATION
 You can find the installation guides on the [wikipage](https://github.com/Waterboy1602/Addarr/wiki).

--- a/addarr.py
+++ b/addarr.py
@@ -389,10 +389,7 @@ def nextOption(update, context):
     context.user_data["position"] = position
 
     choice = context.user_data["choice"]    
-    if choice == i18n.t("addarr.Movie"):
-        message=i18n.t("addarr.messages.This", subjectWithArticle=i18n.t("addarr.MovieWithArticle").lower())
-    else:
-        message=i18n.t("addarr.messages.This", subjectWithArticle=i18n.t("addarr.SeriesWithArticle").lower())
+    message=i18n.t("addarr.searchresults", count=len(searchResult))
     message += f"\n\n*{context.user_data['output'][position]['title']} ({context.user_data['output'][position]['year']})*"
     context.bot.edit_message_text(
         message_id=context.user_data["title_update_msg"],
@@ -724,7 +721,7 @@ def clearUserData(context):
     )
     for x in [
         x
-        for x in ["choice", "title", "position", "output", "paths", "path", "qualityProfiles", "qualityProfile"]
+        for x in ["choice", "title", "position", "output", "paths", "path", "qualityProfiles", "qualityProfile", "update_msg", "title_update_msg", "photo_update_msg"]
         if x in context.user_data.keys()
     ]:
         context.user_data.pop(x)

--- a/addarr.py
+++ b/addarr.py
@@ -540,7 +540,7 @@ def addSerieMovie(update, context):
     path = context.user_data["path"]
     
     service = getService(context)
-    
+    qualityProfile = context.user_data["qualityProfile"]
     if not service.inLibrary(idnumber):
         if service.addToLibrary(idnumber, path, qualityProfile):
             if choice == i18n.t("addarr.Movie"):

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -15,6 +15,8 @@ sonarr:
   languageProfileId: 1
   excludedRootFolders: # If set must not have a trailing slash Eg: /mnt/Media
     - # First excluded folder, add others with a "-" on a new line (same indentation)
+  excludedQualityProfiles:
+    - 
 
 #Radarr Configuration
 radarr:
@@ -32,6 +34,8 @@ radarr:
   minimumAvailability: announced
   excludedRootFolders: # If set must not have a trailing slash Eg: /mnt/Media
     - # First excluded folder, add others with a "-" on a new line (same indentation)
+  excludedQualityProfiles:
+    - 
 
 #Telegram Configuration
 telegram:

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -11,12 +11,14 @@ sonarr:
     password:
   search: true
   seasonFolder: true
-  qualityProfileId: 1
-  languageProfileId: 1
+  languageProfile: English
   excludedRootFolders: # If set must not have a trailing slash Eg: /mnt/Media
     - # First excluded folder, add others with a "-" on a new line (same indentation)
   excludedQualityProfiles:
     - 
+  defaultTags: # If set must be existing tags
+    - telegram
+  listOnlyAdmins: false
 
 #Radarr Configuration
 radarr:
@@ -30,13 +32,15 @@ radarr:
     username:
     password: 
   search: true
-  qualityProfileId: 1
   minimumAvailability: announced
   excludedRootFolders: # If set must not have a trailing slash Eg: /mnt/Media
     - # First excluded folder, add others with a "-" on a new line (same indentation)
   excludedQualityProfiles:
     - 
-
+  defaultTags: # If set must be existing tags
+    - telegram
+  listOnlyAdmins: false
+  
 #Telegram Configuration
 telegram:
   token:
@@ -77,8 +81,9 @@ entrypointAllMovies: allMovies #allMovies or a custom entrypoint
 entrypointTransmission: transmission #transmission or a custom entrypoint
 entrypointSabnzbd: sabnzbd #sabnzbd or a custom entrypoint
 
-##Restrict some commands (Transmission) to only admins 
-enableAdmin: true
+##Restrict some commands to only admins and/or provide extra authorization by usernames
+enableAdmin: false #Check admin.txt
+enableAllowlist: false #Check allowlist.txt - very restrictive!
 
 ##Logging
 logToConsole: true

--- a/definitions.py
+++ b/definitions.py
@@ -10,6 +10,7 @@ LANG_PATH = os.path.join(ROOT_DIR, "translations/")
 CHATID_PATH = os.path.join(ROOT_DIR, "chatid.txt")
 LOG_PATH = os.path.join(ROOT_DIR, "logs", "addarr.log")
 ADMIN_PATH = os.path.join(ROOT_DIR, "admin.txt")
+ALLOWLIST_PATH = os.path.join(ROOT_DIR, "allowlist.txt")
 
 DEFAULT_SETTINGS = {
     "entrypointAuth": "auth", #auth or a custom entrypoint

--- a/radarr.py
+++ b/radarr.py
@@ -15,7 +15,7 @@ logger = logger.getLogger("addarr.radarr", logLevel, config.get("logToConsole", 
 
 config = config["radarr"]
 
-addMovieNeededFields = ["tmdbId", "year", "title", "titleSlug", "images", "tags"]
+addMovieNeededFields = ["tmdbId", "year", "title", "titleSlug", "images"]
 
 
 def search(title):

--- a/sabnzbd.py
+++ b/sabnzbd.py
@@ -2,7 +2,7 @@ import requests
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ConversationHandler
 
-from commons import authentication, checkAdmin, checkId, generateApiQuery
+from commons import authentication, checkAllowed, checkId, generateApiQuery
 from config import config
 from translations import i18n
 import logging
@@ -20,6 +20,10 @@ SABNZBD_SPEED_LIMIT_100 = '100'
 
 
 def sabnzbd(update, context):
+    if config.get("enableAllowlist") and not checkAllowed(update,"regular"):
+        #When using this mode, bot will remain silent if user is not in the allowlist.txt
+        return ConversationHandler.END
+        
     if not config["enable"]:
         context.bot.send_message(
             chat_id=update.effective_message.chat_id,
@@ -33,7 +37,7 @@ def sabnzbd(update, context):
         )
         return SABNZBD_SPEED_LIMIT_100
 
-    if not checkAdmin(update):
+    if not checkAllowed(update, "admin"):
         context.bot.send_message(
             chat_id=update.effective_message.chat_id,
             text=i18n.t("addarr.NotAdmin"),

--- a/sonarr.py
+++ b/sonarr.py
@@ -56,11 +56,11 @@ def inLibrary(tvdbId):
     return next((True for show in parsed_json if show["tvdbId"] == tvdbId), False)
 
 
-def addToLibrary(tvdbId, path):
+def addToLibrary(tvdbId, path, qualityProfileId):
     parameters = {"term": "tvdb:" + str(tvdbId)}
     req = requests.get(commons.generateApiQuery("sonarr", "series/lookup", parameters))
     parsed_json = json.loads(req.text)
-    data = json.dumps(buildData(parsed_json, path))
+    data = json.dumps(buildData(parsed_json, path, qualityProfileId))
     add = requests.post(commons.generateApiQuery("sonarr", "series"), data=data, headers={'Content-Type': 'application/json'})
     if add.status_code == 201:
         return True
@@ -68,9 +68,9 @@ def addToLibrary(tvdbId, path):
         return False
 
 
-def buildData(json, path):
+def buildData(json, path, qualityProfileId):
     built_data = {
-        "qualityProfileId": config["qualityProfileId"],
+        "qualityProfileId": qualityProfileId,
         "languageProfileId": config["languageProfileId"],
         "addOptions": {
             "ignoreEpisodesWithFiles": "true",
@@ -124,3 +124,10 @@ def allSeries():
         return data
     else:
         return False
+
+def getQualityProfiles():
+    parameters = {}
+    req = requests.get(commons.generateApiQuery("sonarr", "qualityProfile", parameters))
+    parsed_json = json.loads(req.text)
+    logger.debug(f"Found Sonarr quality profiles: {parsed_json}")
+    return parsed_json

--- a/translations/addarr.de-de.yml
+++ b/translations/addarr.de-de.yml
@@ -14,6 +14,7 @@ de-de:
   Next result: Nein, zeige mir das nächste Ergebnis
   Last result: Keine weiteren Ergebnisse verfügbar
   Add: Ja, füge dies hinzu
+  Select: Ja, wählen Sie dies
   Select a path: Bitte wähle ein Pfad für die Serie oder den Film
   Select a quality: Bitte wählen Sie ein Qualitätsprofil für den Film oder die Serie
   Authorize: Dieser Chat muss noch autorisiert werden. Was ist dein Passwort?

--- a/translations/addarr.de-de.yml
+++ b/translations/addarr.de-de.yml
@@ -15,6 +15,7 @@ de-de:
   Last result: Keine weiteren Ergebnisse verfügbar
   Add: Ja, füge dies hinzu
   Select a path: Bitte wähle ein Pfad für die Serie oder den Film
+  Select a quality: Bitte wählen Sie ein Qualitätsprofil für den Film oder die Serie
   Authorize: Dieser Chat muss noch autorisiert werden. Was ist dein Passwort?
   Wrong password: Das Password ist nicht korrekt. Probiere es erneut...
   Chatid added: "Dieser Chat würde zur autorisierten liste hinzugefügt. Nun kannst du den Bot benutzen. \befehle müssen erneut ausgeführt werden."

--- a/translations/addarr.en-us.yml
+++ b/translations/addarr.en-us.yml
@@ -14,7 +14,9 @@ en-us:
   Next result: No, show me the next result
   Last result: No more results to show
   Add: Yes, add this
+  Select: Yes, select this
   Select a path: Please select a path for the movie or series
+  Select a quality: Please select a quality profile for the movie or series
   Authorize: You first need to authorize this chat. What is the password?
   Wrong password: You entered the wrong password. Try again...
   Chatid added: "This chat is successfully added to the list of allowed chats. Now you can start using this bot. \nIf you entered a command, you need to execute it again."

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -2,66 +2,64 @@
 es-es: 
   Start: Iniciar
   Stop: Detener
-  Movie: Película
-  MovieWithArticle: Película
-  Serie: Serie
+  Movie: Pelicula
+  MovieWithArticle: pelicula
+  Series: Serie
   SeriesWithArticle: serie
-  Start chatting: Empieza a chatear con Addarr en Telegram. La primera vez que uses "start" te pedirá introducir tu contraseña configurada.
-  End: La adición de películas o series ha finalizado.
-  Title: "Introduce el título:"
-  What is this?: Esto es una película o una serie?
-  New: Ejecuta un nuevo comando de búsqueda
-  Next result: No, muéstrame el siguiente resultado
+  Start chatting: Empieza a chatear con Addarr en Telegram. La primera vez que uses "start" te pedira introducir tu contraseña configurada.
+  End: La adicion de peliculas o series ha finalizado.
+  Title: "Introduce el titulo:"
+  What is this?: Esto es una pelicula o una serie?
+  New: Ejecuta un nuevo comando de busqueda
+  Next result: No, muestrame el siguiente resultado
   Last result: No hay más resultados
-  Add: Sí, añadir
-  Select: Sí, selecciona esto
+  Add: Si, añadir
+  Select: Si, selecciona esto
   Select a path: Por favor elige una ruta donde guardar
-  Select a quality: Por favor, seleccione la calidad para la película o serie
+  Select a quality: Por favor, seleccione la calidad para la pelicula o serie
   Authorize: Necesitas autorizar este chat primero. ¿Cuál es la contraseña?
   Wrong password: Contraseña incorrecta. Prueba otra vez...
   Chatid added: "Este chat ha sido autorizado correctamente. Ya puedes utilizar el bot."
   NotAdmin: "Necesitas ser admin para ejecutar este comando."
-  Chatid already allowed: "Este chat ya está autorizado."
+  Chatid already allowed: "Este chat ya esta autorizado."
   Help: "Quieres volver a ver este texto? Usa /%{help}.
     \n• Para autenticarte antes del primer uso debes usar /%{authenticate}.
     \n• Para añadir una serie o película usa /%{add}.
     \n• Para añadir directamente una película o serie usa /%{movie} or /%{serie}.
     \n• Para comprobar que series hay en Sonarr usa /%{allSeries}.
-    \n• Para comprobar que películas hay en Radarr usa /%{allMovies}.
-    \n• Para cambiar la velocidad de descarga de Transmission usa /%{transmission}.
-    \n• To change the up- and download speed of Sabnzbd use /%{sabnzbd}."
-  Missing config: "You are missing the following configkeys in your config.yaml-file: %{missingKeys}.
-    \nAdd these before restarting the bot."
-  Wrong values: "The following configkeys has a wrong value in your config.yaml-file: %{wrongValues}.
-    \nChange these before restarting the bot."
+    \n• Para comprobar que películas hay en Radarr usa /%{allMovies}."
+  Missing config: "Te faltan las siguientes keys en tu config.yaml-file: %{missingKeys}.
+    \nAñadelas antes de reiniciar el bot."
+  Wrong values: "Te faltan las siguientes keys tienen un valor incorrecto en tu config.yaml-file: %{wrongValues}.
+    \nCambialas antes de reiniciar el bot."
 
   messages:
-    Add: Sí, añade esta %{subject}
+    Add: Si, añade esta %{subject}
     This: Es esta la %{subjectWithArticle} que quieres añadir?
     Failed: Oops, fallo al añadir %{subjectWithArticle}. Prueba otra vez.
     Success: "La %{subjectWithArticle} se ha añadido correctamente 🙂"
     Exist: La %{subjectWithArticle} ya existe 😉
   
   searchresults:
-    zero: No se han encontrado resultados
-    one: Un resultado de búsqueda
-    other: "%{count} resultados de búsqueda"
+    zero: No se han encontrado resultados.
+    one: Se ha encontrado un resultado. 
+    other: "Se han encontrado %{count} resultados. "
 
   Transmission:
-    NotEnabled: "La función de Transmission no está activada."
-    Speed: "Qué velocidad quieres que use Transmission?"
+    NotEnabled: "La funcion de Transmission no esta activada."
+    Speed: "Que velocidad quieres que use Transmission?"
     TSL: Temporary Speed Limits
     Normal: Velocidad normal
     ChangedToTSL: "Temporary Speed Limits está habilitado."
     ChangedToNormal: "Temporary Speed Limits está deshabilitado."
 
   Sabnzbd:
-    NotEnabled: La función Sabnzbd no está activada.
-    Speed: Qué velocidad quieres que use Sabnzbd?
+    NotEnabled: La funcion Sabnzbd no esta activada.
+    Speed: Que velocidad quieres que use Sabnzbd?
     Limit25: 25%
     Limit50: 50%
-    Limit100: Sin límite
-    ChangedTo50: Límite aplicado en 50%
-    ChangedTo25: Límite aplicado en 25%
-    ChangedTo100: Ningún límite aplicado
+    Limit100: Sin limite
+    ChangedTo50: Limite aplicado en 50%
+    ChangedTo25: Limite aplicado en 25%
+    ChangedTo100: Ningun limite aplicado
     Error: Algo ha fallado cuando se ha intentado cambiar la velocidad

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -14,6 +14,7 @@ es-es:
   Next result: No, muéstrame el siguiente resultado
   Last result: No hay más resultados
   Add: Sí, añadir
+  Select: Sí, selecciona esto
   Select a path: Por favor elige una ruta donde guardar
   Select a quality: Por favor, seleccione la calidad para la película o serie
   Authorize: Necesitas autorizar este chat primero. ¿Cuál es la contraseña?

--- a/translations/addarr.es-es.yml
+++ b/translations/addarr.es-es.yml
@@ -15,6 +15,7 @@ es-es:
   Last result: No hay más resultados
   Add: Sí, añadir
   Select a path: Por favor elige una ruta donde guardar
+  Select a quality: Por favor, seleccione la calidad para la película o serie
   Authorize: Necesitas autorizar este chat primero. ¿Cuál es la contraseña?
   Wrong password: Contraseña incorrecta. Prueba otra vez...
   Chatid added: "Este chat ha sido autorizado correctamente. Ya puedes utilizar el bot."

--- a/translations/addarr.it-it.yml
+++ b/translations/addarr.it-it.yml
@@ -14,6 +14,7 @@ it-it:
   Next result: No, mostra il prossimo risultato
   Last result: Non ci sono altri risultati
   Add: Sì, aggiungilo
+  Select: Sì, seleziona questo
   Select a path: Per favore scegli una cartella per il film o per la serie
   Select a quality: Per favore seleziona un profilo di qualità per il film o la serie
   Authorize: Devi prima autenticare questa chat. Qual'è la password?

--- a/translations/addarr.it-it.yml
+++ b/translations/addarr.it-it.yml
@@ -15,6 +15,7 @@ it-it:
   Last result: Non ci sono altri risultati
   Add: Sì, aggiungilo
   Select a path: Per favore scegli una cartella per il film o per la serie
+  Select a quality: Per favore seleziona un profilo di qualità per il film o la serie
   Authorize: Devi prima autenticare questa chat. Qual'è la password?
   Wrong password: La password è sbagliata. Riprova...
   Chatid added: "Questa chat è stata aggiunta alla lista delle chat autorizzate. Ora puoi utilizzare il bot. \nSe avevi inviato un comando, dovrai inviarlo di nuovo."

--- a/translations/addarr.nl-be.yml
+++ b/translations/addarr.nl-be.yml
@@ -15,6 +15,7 @@ nl-be:
   Last result: Geen resultaten meer te tonen
   Add: Ja, voeg deze toe
   Select a path: Kies een pad voor deze film of serie
+  Select a quality: Kies een kwaliteitsprofiel voor de film of serie
   Authorize: Je moet eerst deze chat toestemming geven. Wat is het wachtwoord?
   Wrong password: Het wachtwoord is verkeerd. Probeer opnieuw...
   Chatid added: "Deze chat is succesvol toegevoegd aan de lijst met toegestane chats. Nu kan je deze bot gebruiken. \nAls je een commando had ingegeven, moet je deze opnieuw uitvoeren."

--- a/translations/addarr.nl-be.yml
+++ b/translations/addarr.nl-be.yml
@@ -14,6 +14,7 @@ nl-be:
   Next result: Nee, toon me volgend resultaat
   Last result: Geen resultaten meer te tonen
   Add: Ja, voeg deze toe
+  Select: Ja, selecteer dit
   Select a path: Kies een pad voor deze film of serie
   Select a quality: Kies een kwaliteitsprofiel voor de film of serie
   Authorize: Je moet eerst deze chat toestemming geven. Wat is het wachtwoord?

--- a/translations/addarr.pl-pl.yml
+++ b/translations/addarr.pl-pl.yml
@@ -14,6 +14,7 @@ pl-pl:
   Next result: Próbuj dalej
   Last result: Brak więcej wyników wyszukania
   Add: Tak, chcę to!
+  Select: Wybierz: Tak, wybierz to
   Select a path: Wybierz ścieżkę dla filmu lub serialu
   Select a quality: Proszę wybrać profil jakościowy dla filmu lub serialu
   Authorize: Musisz zautoryzować ten czat. Jakie jest hasło?

--- a/translations/addarr.pl-pl.yml
+++ b/translations/addarr.pl-pl.yml
@@ -15,6 +15,7 @@ pl-pl:
   Last result: Brak więcej wyników wyszukania
   Add: Tak, chcę to!
   Select a path: Wybierz ścieżkę dla filmu lub serialu
+  Select a quality: Proszę wybrać profil jakościowy dla filmu lub serialu
   Authorize: Musisz zautoryzować ten czat. Jakie jest hasło?
   Wrong password: Hasło nieprawidłowe. Spróbuj ponownie...
   Chatid added: "Ten czat został dodany do whitelisty. Teraz możesz używać tego bota."

--- a/translations/addarr.pt-pt.yml
+++ b/translations/addarr.pt-pt.yml
@@ -15,6 +15,7 @@ pt-pt:
   Last result: Não há mais resultados a apresentar
   Add: Sim, adicione este
   Select a path: Seleccione um caminho para o filme ou série
+  Select a quality: Por favor, seleccione um perfil de qualidade para o filme ou série
   Authorize: Primeiro tem de autorizar este chat. Indique a password
   Wrong password: Introduziu a password errada. Tente novamente
   Chatid added: "Este chat foi adicionado à lista de chats autorizados. Pode agora utilizar este bot.\nSe introduziu um comando, deverá executá-lo novamente."

--- a/translations/addarr.pt-pt.yml
+++ b/translations/addarr.pt-pt.yml
@@ -14,6 +14,7 @@ pt-pt:
   Next result: Não, mostre-me o resultado seguinte
   Last result: Não há mais resultados a apresentar
   Add: Sim, adicione este
+  Select: Sim, seleccione isto
   Select a path: Seleccione um caminho para o filme ou série
   Select a quality: Por favor, seleccione um perfil de qualidade para o filme ou série
   Authorize: Primeiro tem de autorizar este chat. Indique a password

--- a/transmission.py
+++ b/transmission.py
@@ -4,7 +4,7 @@ import yaml
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ConversationHandler
 
-from commons import authentication, checkAdmin, checkId
+from commons import authentication, checkAllowed, checkId
 from config import config
 from translations import i18n
 
@@ -14,6 +14,10 @@ TSL_LIMIT = 'limited'
 TSL_NORMAL = 'normal'
 
 def transmission(update, context):
+    if config.get("enableAllowlist") and not checkAllowed(update,"regular"):
+        #When using this mode, bot will remain silent if user is not in the allowlist.txt
+        return ConversationHandler.END
+    
     if not config["enable"]:
         context.bot.send_message(
             chat_id=update.effective_message.chat_id,
@@ -27,7 +31,7 @@ def transmission(update, context):
         )
         return TSL_NORMAL
 
-    if not checkAdmin(update):
+    if not checkAllowed(update, "admin"):
         context.bot.send_message(
             chat_id=update.effective_message.chat_id,
             text=i18n.t("addarr.NotAdmin"),


### PR DESCRIPTION
Changes:
- Changed messages flow. Once something is selected it is replaced with the new selection. (I found it chaotic how many messages were left after adding a single movie/series)
- Added the capability to select quality profiles by name on Sonarr and Radarr (and possibility to exclude some of them)
- Added the capability to define default tags by name on config
- Changed config integer identifiers to text identifiers
- Added option to restrict series/movies list to admin
- Allowlist option to define an allowlist by usernames/ids (more secure, but take in mind that is very restrictive)
- Other minor fixes

All modifications were done following the already written code format.

These changes should fix the following open issues:
https://github.com/Waterboy1602/Addarr/issues/35
https://github.com/Waterboy1602/Addarr/issues/49
https://github.com/Waterboy1602/Addarr/issues/75
https://github.com/Waterboy1602/Addarr/issues/85
https://github.com/Waterboy1602/Addarr/issues/87
https://github.com/Waterboy1602/Addarr/issues/92
https://github.com/Waterboy1602/Addarr/issues/105