### PR TITLE
fix: Getting chat last name during auth

### DIFF
--- a/src/commons.py
+++ b/src/commons.py
@@ -113,11 +113,11 @@ def getChatName(context, chatid):
     elif chat.title:
         chatName = str(chat.title)
     elif chat.last_name and chat.first_name:
-        chatName = str(chat.lastname) + str(chat.first_name)
+        chatName = str(chat.last_name) + str(chat.first_name)
     elif chat.first_name:
         chatName = str(chat.first_name)
     elif chat.last_name:
-        chatName = str(chat.lastname)
+        chatName = str(chat.last_name)
     else:
         chatName = None
 


### PR DESCRIPTION
Fixes the following issue I ran into when trying to authenticate...

```
AttributeError: 'Chat' object has no attribute 'lastname'
```

Turns out, the code has a typo.