### PR TITLE
Update sonarr v3>v4 languageProfile removal

### DIFF
--- a/src/sonarr.py
+++ b/src/sonarr.py
@@ -82,12 +82,12 @@ def removeFromLibrary(tvdbId):
 
 
 def buildData(json, path, qualityProfileId, tags, seasonsSelected):
+#    "languageProfileId": getLanguageProfileId(config["languageProfile"]),
     built_data = {
         "qualityProfileId": qualityProfileId,
-        "languageProfileId": getLanguageProfileId(config["languageProfile"]),
         "addOptions": {
-            "ignoreEpisodesWithFiles": "true",
-            "ignoreEpisodesWithoutFiles": "false",
+            "ignoreEpisodesWithFiles": True,
+            "ignoreEpisodesWithoutFiles": False,
             "searchForMissingEpisodes": config["search"],
         },
         "rootFolderPath": path,


### PR DESCRIPTION
From sonarr v3 to v4 it is removed the Language Profiles and this is done via Custom Formats so adapted the query because it was failing

Same as issue https://github.com/Waterboy1602/Addarr/issues/138